### PR TITLE
Fix a buggy interaction with i3wm; Fill out server information

### DIFF
--- a/src/bus/receiver.rs
+++ b/src/bus/receiver.rs
@@ -29,13 +29,12 @@ impl OrgFreedesktopNotifications for BusNotification {
         Ok(capabilities)
     }
 
-    // TODO: fill out this.
     fn get_server_information(&self) -> Result<(String, String, String, String), tree::MethodErr> {
         Ok((
-            "dummy".to_string(),
-            "dummy".to_string(),
-            "dummy".to_string(),
-            "dummy".to_string(),
+            env!("CARGO_PKG_NAME").to_string(),
+            env!("CARGO_PKG_AUTHORS").to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+            "1.2".to_string(),
         ))
     }
 

--- a/src/management/mod.rs
+++ b/src/management/mod.rs
@@ -127,7 +127,7 @@ impl NotifyWindowManager {
                             &cfg.layout.as_ref().unwrap().hook,
                             &cfg.layout.as_ref().unwrap().offset,
                             &prev_rect,
-                            &Rect::EMPTY,
+                            &window_rect,
                         )
                     } else {
                         LayoutBlock::find_anchor_pos(


### PR DESCRIPTION
I'm using `i3wm` as a window manager and had a bug where `self_anchor` of a root block behaved as if it's `TL` regardless of its actual value. This change fixes the bug. I also tested it with another window manager (`marco`) and it doesn't seem to break anything.

I'm not sure I fixed the correct root cause though, since I still don't get what caused the bug. It makes sense to me that all anchors would behave like `TL` when `self_rect` size is zero, but it only happened in some WMs and I don't know why.

---

I also filled out server information. Cargo environmental variables seem reasonable to me. Some programs use these to decide the content of notifications (In my case it was Telegram not sending icons).