### PR TITLE
Add libXscrnSaver dependency for nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
           xorg.libXi
           xorg.libXrandr
           xorg.libXcursor
+          xorg.libXScrnSaver
         ];
       in rec {
         # `nix build`


### PR DESCRIPTION
Hi, building this project with nix fails on my setup with
```
builder for '/nix/store/l5r6adfk9k7j14agw69acblqz0ydr2i6-wired-0.9.3.drv' failed with exit code 101; last 10 log lines:
    cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR_x86_64_unknown_linux_gnu
    cargo:rerun-if-env-changed=HOST_PKG_CONFIG_SYSROOT_DIR
    cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR

    --- stderr
    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Failure { command: "\"pkg-config\" \"--libs\" \"--cflags\" \"xscrnsaver\" \"xscrnsaver >= 1.2\"", output: Output { status: ExitStatus(ExitStatus(256)), stdout: "", stderr: "Package xscrnsaver was not found in the pkg-config search path.\nPerhaps you should add the directory containing `xscrnsaver.pc'\nto the PKG_CONFIG_PATH environment variable\nNo package 'xscrnsaver' found\nPackage xscrnsaver was not found in the pkg-config search path.\nPerhaps you should add the directory containing `xscrnsaver.pc'\nto the PKG_CONFIG_PATH environment variable\nNo package 'xscrnsaver' found\n" } }', /sources/x11-2.18.2/build.rs:36:67
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  warning: build failed, waiting for other jobs to finish...
```
This seems due to the libXscrnSaver dependency missing from the nix flake definition.