### PR TITLE
Fix anchor position names

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -449,13 +449,13 @@ pub struct Offset {
 
 #[derive(Debug, Deserialize, Clone)]
 pub enum AnchorPosition {
-    ML,
     TL,
-    MT,
+    TM,
     TR,
+    ML,
     MR,
     BR,
-    MB,
+    BM,
     BL,
 }
 
@@ -569,13 +569,13 @@ impl Padding {
 impl AnchorPosition {
     pub fn get_pos(&self, rect: &Rect) -> Vec2 {
         match self {
-            AnchorPosition::ML => rect.mid_left(),
             AnchorPosition::TL => rect.top_left(),
-            AnchorPosition::MT => rect.mid_top(),
+            AnchorPosition::TM => rect.top_mid(),
             AnchorPosition::TR => rect.top_right(),
+            AnchorPosition::ML => rect.mid_left(),
             AnchorPosition::MR => rect.mid_right(),
             AnchorPosition::BR => rect.bottom_right(),
-            AnchorPosition::MB => rect.mid_bottom(),
+            AnchorPosition::BM => rect.bottom_mid(),
             AnchorPosition::BL => rect.bottom_left(),
         }
     }

--- a/src/maths_utility.rs
+++ b/src/maths_utility.rs
@@ -133,9 +133,9 @@ impl Rect {
 
     pub fn mid_right(&self) -> Vec2 { Vec2 { x: self.right(), y: (self.bottom() + self.top()) / 2.0 } }
 
-    pub fn mid_top(&self) -> Vec2 { Vec2 { x: (self.left() + self.right()) / 2.0, y: self.top() } }
+    pub fn top_mid(&self) -> Vec2 { Vec2 { x: (self.left() + self.right()) / 2.0, y: self.top() } }
 
-    pub fn mid_bottom(&self) -> Vec2 { Vec2 { x: (self.left() + self.right()) / 2.0, y: self.bottom() } }
+    pub fn bottom_mid(&self) -> Vec2 { Vec2 { x: (self.left() + self.right()) / 2.0, y: self.bottom() } }
 
     pub fn set_right(&mut self, right: f64) {
         self.x = right - self.width


### PR DESCRIPTION
The names of the anchor position in the code do not match with names in the [wiki](https://github.com/Toqozz/wired-notify/wiki/Blocks).  I have changed MT and MB to TM and BM in the code, respectively, following the order used in the rest of the anchor position names (i.e., first the vertical position and then the horizontal position).

Property | Description
-- | --
hook | Represents where this block should be joined to the parent block.parent_anchor: Where to attach on the parent (TL, TM, TR, MR, BR, BM, BL, ML).self_anchor: Where to attach on this block (TL, TM, TR, MR, BR, BM, BL, ML).

