### PR TITLE
Add `interact_and_close` for notification config.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -432,6 +432,8 @@ pub struct ShortcutsConfig {
     pub notification_action2_and_close: Option<u16>,
     pub notification_action3_and_close: Option<u16>,
     pub notification_action4_and_close: Option<u16>,
+
+    pub notification_interact_and_close: Option<u16>,
 }
 
 impl Default for ShortcutsConfig {
@@ -451,6 +453,7 @@ impl Default for ShortcutsConfig {
             notification_action2_and_close: None,
             notification_action3_and_close: None,
             notification_action4_and_close: None,
+            notification_interact_and_close: None,
         }
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -317,6 +317,7 @@ impl NotifyWindowManager {
                 config.shortcuts.notification_action2_and_close,
                 config.shortcuts.notification_action3_and_close,
                 config.shortcuts.notification_action4_and_close,
+                config.shortcuts.notification_interact_and_close,
             ]
             .contains(&pressed)
             {
@@ -335,6 +336,12 @@ impl NotifyWindowManager {
             } else if pressed == config.shortcuts.notification_action4
                 || pressed == config.shortcuts.notification_action4_and_close {
                 3
+            } else if pressed == config.shortcuts.notification_interact
+                || pressed == config.shortcuts.notification_interact_and_close {
+                if let Some(window) = self.find_window_mut(window_id) {
+                    window.process_mouse_click();
+                }
+                return;
             } else {
                 // `pressed` did not match any action key.
                 return;


### PR DESCRIPTION
Exactly like it sounds.

Added it because buttons now can be just buttons, with a click to deny/accept something, for example.

It will make easier for scripts I think for people in the future whose functionality deems cool :)

![screen_土_ 3月_19_06:01:23](https://user-images.githubusercontent.com/51831435/159114906-970c7822-a76b-43f4-8a26-b3f9e2fb2e09.gif)
