### PR TITLE
layout.rs: AppName with Vec<String> comparison.

### DIFF
--- a/src/rendering/layout.rs
+++ b/src/rendering/layout.rs
@@ -42,7 +42,7 @@ pub enum RenderCriteria {
     Body,
     HintImage,
     AppImage,
-    AppName,
+    AppName(Vec<String>),
     Progress,
     ActionDefault,
     ActionOther(usize),
@@ -87,7 +87,16 @@ impl LayoutBlock {
                 RenderCriteria::Body => if n.body.is_empty() { should_draw = false },
                 RenderCriteria::AppImage => if n.app_image.is_none() { should_draw = false },
                 RenderCriteria::HintImage => if n.hint_image.is_none() { should_draw = false },
-                RenderCriteria::AppName => if n.app_name.is_empty() { should_draw = false },
+                RenderCriteria::AppName(apps) => {
+                    should_draw = false;
+                    let mut to = IntoIterator::into_iter(apps);
+                    while let Some(s) = to.next() {
+                        if n.app_name.eq(s) {
+                            should_draw = true;
+                            break;
+                        }
+                    }
+                },
                 RenderCriteria::Progress => if n.percentage.is_none() { should_draw = false },
                 RenderCriteria::ActionDefault => if n.get_default_action().is_none() { should_draw = false },
                 RenderCriteria::ActionOther(i) => if n.get_other_action(*i).is_none() { should_draw = false },
@@ -100,7 +109,15 @@ impl LayoutBlock {
                 RenderCriteria::Body => if !n.body.is_empty() { should_draw = false },
                 RenderCriteria::AppImage => if !n.app_image.is_none() { should_draw = false },
                 RenderCriteria::HintImage => if !n.hint_image.is_none() { should_draw = false },
-                RenderCriteria::AppName => if !n.app_name.is_empty() { should_draw = false },
+                RenderCriteria::AppName(apps) => {
+                    let mut to = IntoIterator::into_iter(apps);
+                    while let Some(s) = to.next() {
+                        if n.app_name.eq(s) {
+                            should_draw = false;
+                            break;
+                        }
+                    }
+                },
                 RenderCriteria::Progress => if !n.percentage.is_none() { should_draw = false },
                 RenderCriteria::ActionDefault => if !n.get_default_action().is_none() { should_draw = false },
                 RenderCriteria::ActionOther(i) => if !n.get_other_action(*i).is_none() { should_draw = false },


### PR DESCRIPTION
Fixes #62.

It may be poor in performance?... To be honest I don't really know since Rust isn't for me, but so far has been pretty fast here, no additional memory usage as far as I can see, etc.

However it's always good to make sure so this'll be a draft PR.

```rust
// Element 1.
render_criteria      : [AppName(["app-one", "app-two"])],
// Element 2.
render_anti_criteria : [AppName(["app-one", "app-two"])],
```

---

Also, Wired awaits `Action` sends a signal back to the sender (`notify-call` i.e.) through a loop? If yes, we need to break it in case it's not rendered, which is not happening right now.