### PR TITLE
Improve Nix Flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,26 +57,49 @@ $ yay -S wired-git
 ```
 
 ### Nix (Flakes)
-Wired can be either run directly from the cloned repository:
+Flake support was added to Nix in version 2.4. As of Nix 2.8, you must enable the `nix-command` and `flakes` experimental features.
+
+Wired can be run directly from the repository, using:
 ```sh
-$ git clone https://github.com/Toqozz/wired-notify.git
-$ cd wired-notify
-$ nix run
+nix run 'github:Toqozz/wired-notify'
 ```
-Or be installed as a package.  
-Simply add it to the inputs of your system flake
+
+To install Wired to your user profile:
+```sh
+nix profile install 'github:Toqozz/wired-notify'
+```
+
+To use it in another flake:
 ```nix
 {
   inputs = {
-    wired-notify.url = "github:toqozz/wired-notify/master";
+    wired.url = github:Toqozz/wired-notify;
   };
 }
 ```
-And install it as a system-wide package
+
+For example, to install it for all users in NixOS:
 ```nix
-# Add this Line i.e. to your environment.systemPackages
-wired-notify.packages.x86_64-linux.wired
-# Do not forget to pass the wired-notify input to where your environment.systemPackages lies
+{
+  inputs = {
+    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
+    wired.url = github:Toqozz/wired-notify;
+  };
+  outputs = { self, nixpkgs, wired }: let
+    std = nixpkgs.lib;
+    system = "x86_64-linux";
+  in {
+    nixosConfigurations.alice = std.nixosSystem {
+      inherit system;
+      modules = [
+        ./configuration.nix
+        {
+          environment.systemPackages = [ wired.packages.${system}.wired ];
+        }
+      ];
+    };
+  };
+}
 ```
 
 ### NetBSD

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ nix run 'github:Toqozz/wired-notify'
 
 To install Wired to your user profile:
 ```sh
+# note: the systemd service will not be available if installed with this method
 nix profile install 'github:Toqozz/wired-notify'
 ```
 
@@ -97,6 +98,25 @@ For example, to install it for all users in NixOS:
           environment.systemPackages = [ wired.packages.${system}.wired ];
         }
       ];
+    };
+  };
+}
+```
+
+This flake also provides a module for [home-manager](https://github.com/nix-community/home-manager). To use it in your configuration:
+```nix
+{
+  # ...
+  outputs = { self, home-manager, wired, ... }: {
+    homeConfigurations.alice = home-manager.lib.homeManagerConfiguration {
+      # ...
+      extraModules = [ wired.homeManagerModules.default ];
+      configuration = { pkgs, ... }: {
+        services.wired = {
+          enable = true;
+          config = ./wired.ron;
+        };
+      };
     };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,9 @@
     "alejandra": {
       "inputs": {
         "flakeCompat": "flakeCompat",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1652974241,
@@ -37,7 +39,9 @@
     },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1652722411,
@@ -55,46 +59,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652073560,
-        "narHash": "sha256-WigD7BFlm4Wr12ujm9HE7yH3U3LWtfoGu3im6EAu9RE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "43c99bebdab0ed66de2c4264e48b25999c2d9573",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
         "lastModified": 1652840887,
         "narHash": "sha256-gEK4NNa4GwIgTZE63kt/4WTFAWRTJVSa30+h4ZjFh9U=",
-        "owner": "NixOS",
+        "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "52dc75a4fee3fdbcb792cb6fba009876b912bfe0",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1653045779,
-        "narHash": "sha256-zZQNFhsX38Mg6mHS78oZAktaz1QY1Y2Zp4shHth52vk=",
         "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b441d14d06958b02409f0c6267b46f0aff6b8c43",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-21.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -103,7 +77,7 @@
       "inputs": {
         "alejandra": "alejandra",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs",
         "utils": "utils"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,44 +1,81 @@
 {
   "nodes": {
-    "naersk": {
+    "alejandra": {
       "inputs": {
+        "flakeCompat": "flakeCompat",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1629707199,
-        "narHash": "sha256-sGxlmfp5eXL5sAMNqHSb04Zq6gPl+JeltIZ226OYN0w=",
-        "owner": "nmattia",
-        "repo": "naersk",
-        "rev": "df71f5e4babda41cd919a8684b72218e2e809fa9",
+        "lastModified": 1652974241,
+        "narHash": "sha256-0AolxQtKj3Oek0WSbODDpPVO5Ih8PXHOA3qXEKPB4dQ=",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "rev": "0be1462419fc73270a5dc0f84f8092603890b029",
         "type": "github"
       },
       "original": {
-        "owner": "nmattia",
+        "owner": "kamadorueda",
+        "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "flakeCompat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648199409,
+        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1652722411,
+        "narHash": "sha256-FxzNgYiH9c91hUVAntcjrqY//KOTUPP2a4e8Wyuysxg=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "94beb7a3edfeb3bcda65fa3f2ebc48ec6b40bf72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
         "repo": "naersk",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1629813367,
-        "narHash": "sha256-pImtQoxdB9b581kdpV6EWeQA6qH6u2T/NhZ+7LoFi84=",
-        "owner": "NixOS",
+        "lastModified": 1652073560,
+        "narHash": "sha256-WigD7BFlm4Wr12ujm9HE7yH3U3LWtfoGu3im6EAu9RE=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "24ecbeee3cd2737e1be2f46af294d4e5da78d8ce",
+        "rev": "43c99bebdab0ed66de2c4264e48b25999c2d9573",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable-small",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1629813367,
-        "narHash": "sha256-pImtQoxdB9b581kdpV6EWeQA6qH6u2T/NhZ+7LoFi84=",
+        "lastModified": 1652840887,
+        "narHash": "sha256-gEK4NNa4GwIgTZE63kt/4WTFAWRTJVSa30+h4ZjFh9U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "24ecbeee3cd2737e1be2f46af294d4e5da78d8ce",
+        "rev": "52dc75a4fee3fdbcb792cb6fba009876b912bfe0",
         "type": "github"
       },
       "original": {
@@ -46,20 +83,37 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1653045779,
+        "narHash": "sha256-zZQNFhsX38Mg6mHS78oZAktaz1QY1Y2Zp4shHth52vk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b441d14d06958b02409f0c6267b46f0aff6b8c43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "alejandra": "alejandra",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "utils": "utils"
       }
     },
     "utils": {
       "locked": {
-        "lastModified": 1629481132,
-        "narHash": "sha256-JHgasjPR0/J1J3DRm4KxM4zTyAj4IOJY8vIl75v/kPI=",
+        "lastModified": 1652776076,
+        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "997f7efcb746a9c140ce1f13c72263189225f482",
+        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,9 @@
         # `nix fmt` (added in Nix 2.8)
         # (generating this outside of `eachDefaultSystem` because alejandra's supported systems may not match ours)
         formatter = std.mapAttrs (system: pkgs: pkgs.default) alejandra.packages;
+
+        # consumed by github:nix-community/home-manager
+        homeManagerModules.default = import ./home-manager.nix;
       }
       // (
         utils.lib.eachDefaultSystem (system: let

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,16 @@
   description = "Lightweight notification daemon with highly customizable layout blocks, written in Rust.";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/release-21.11;
+    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
     utils.url = github:numtide/flake-utils;
-    naersk.url = github:nix-community/naersk;
-    alejandra.url = github:kamadorueda/alejandra;
+    naersk = {
+      url = github:nix-community/naersk;
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    alejandra = {
+      url = github:kamadorueda/alejandra;
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
               # Without this wired_derive build would fail
               singleStep = true;
               # install extra files (i.e. the systemd service)
-              postInstall =''
+              postInstall = ''
                 # /usr/bin/wired doesn't exist, here, because the binary will be somewhere in /nix/store,
                 # so this fixes the bin path in the systemd service and writes the updated file to the output dir.
                 mkdir -p $out/usr/lib/systemd/system

--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,6 @@
               pname = "wired";
               src = ./.;
               meta = {
-                description = self.description;
                 homepage = "https://github.com/Toqozz/wired-notify";
                 downloadPage = "https://github.com/Toqozz/wired-notify/releases";
                 license = std.licenses.mit;
@@ -60,8 +59,19 @@
               ];
               # Without this wired_derive build would fail
               singleStep = true;
+              # install extra files (i.e. the systemd service)
+              postInstall =''
+                # /usr/bin/wired doesn't exist, here, because the binary will be somewhere in /nix/store,
+                # so this fixes the bin path in the systemd service and writes the updated file to the output dir.
+                mkdir -p $out/usr/lib/systemd/system
+                substitute ./wired.service $out/usr/lib/systemd/system/wired.service --replace /usr/bin/wired $out/bin/wired
+                # install example/default config files to etc/wired -- Arch packages seem to use etc/{pkg} for this,
+                # so there's precedent
+                install -Dm444 -t $out/etc/wired wired.ron wired_multilayout.ron
+              '';
             };
           };
+
           # `nix build`
           packages.wired = pkgs.wired;
           packages.default = self.packages.${system}.wired;

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -1,0 +1,35 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+with builtins; let
+  std = pkgs.lib;
+  cfg = config.services.wired;
+in {
+  options.services.wired = with lib; {
+    enable = mkEnableOption "wired notification daemon";
+    package = mkOption {
+      type = types.package;
+      default = pkgs.wired;
+      description = "Package providing wired.";
+    };
+    config = mkOption {
+      type = types.path;
+      default = ./wired.ron;
+      description = "File containing wired configuration.";
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    home.packages = [cfg.package];
+    # Ideally, we could generate the config from a Nix expression,
+    # but that's complicated, so right now this just symlinks a file.
+    xdg.configFile."wired/wired.ron".source = cfg.config;
+    # As far as I know, the only "official" way to install systemd units
+    # through home-manager is to define `systemd.user.<unit name>`,
+    # which only allows unit configuration directly from Nix (i.e. you
+    # can't just give it a raw file). So, this just installs the existing service.
+    xdg.configFile."systemd/user/wired.service".source = "${cfg.package}/usr/lib/systemd/system/wired.service";
+  };
+}

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -30,6 +30,6 @@ in {
     # through home-manager is to define `systemd.user.<unit name>`,
     # which only allows unit configuration directly from Nix (i.e. you
     # can't just give it a raw file). So, this just installs the existing service.
-    xdg.configFile."systemd/user/wired.service".source = "${cfg.package}/usr/lib/systemd/system/wired.service";
+    xdg.dataFile."systemd/user/wired.service".source = "${cfg.package}/usr/lib/systemd/system/wired.service";
   };
 }


### PR DESCRIPTION
I wanted to use this from a [home-manager](https://github.com/nix-community/home-manager) configuration, and the easiest way for me to add packages to my config is with an overlay. This repo doesn't have an overlay, though, so I've added one.

Here's the full change log:
* Explicitly specify the `nixpkgs` input, instead of using the host system's flake registry
  * Because the flake registry fallthrough can be pretty confusing
* Propagate `nixpkgs` input to other inputs
  * To avoid potentially downloading redundant copies of things
* Update `naersk` url
  * Because that repository has been moved since this flake was written
* Add `formatter` output, for `nix fmt` (using https://github.com/kamadorueda/alejandra)
* Add overlays for each supported system
  * Ideally it would just be one overlay (`overlays.default`), but, as far as I can tell, Naersk requires specifying a system, so there has to be an overlay for each one.
* Move `wired` package definition into overlays
* Change `packages.${system}.wired` to point to `overlays.${system}.wired`
* Add metadata to `wired` package
* Change `wired` package output to include `wired.service`, `wired.ron`, and `wired_multilayout.ron`
* Replace `default*` outputs with `*.default`
  * Those have been deprecated since Nix 2.7
* Update flake.lock
* Change the README to give more explicit instructions and to suggest using `nix run` without first manually cloning the repository
* Add instructions to README for installing to user's Nix profile
* Add home-manager module
* Add example to README for using the home-manager module
* Format `flake.nix` and `home-manager.nix`

This should be completely backwards compatible, as far as I know.

The `wired.service` unit is written to `$out/usr/lib/systemd/system` -- the table in #70 says that `/usr/lib/systemd/system` is for units installed by the system's package manager, and, since Nix is, among other things, a package manager, that seems correct. If I remember correctly, this also means that installing Wired on NixOS will make the service file visible to systemd on that path.

The home-manager module, though, makes a symlink to `wired.service` from `${XDG_DATA_HOME}/systemd/user`. `man 5 systemd.unit` specifies that user-installed packages should write units to that directory, so, because home-manager installs packages per-user, that's what I went with.