### PR TITLE
Fix deprecated associated function

### DIFF
--- a/src/rendering/blocks/image_block.rs
+++ b/src/rendering/blocks/image_block.rs
@@ -134,7 +134,7 @@ impl DrawableLayoutElement for ImageBlockParameters {
                     let filter_type = self.filter_mode.to_image_mode();
                     let px = img
                         .resize_exact(self.scale_width as u32, self.scale_height as u32, filter_type)
-                        .to_bgra() // Cairo reads pixels back-to-front, so ARgb32 is actually BgrA32.
+                        .to_bgra8() // Cairo reads pixels back-to-front, so ARgb32 is actually BgrA32.
                         .into_raw();
                     Some(px)
                 }


### PR DESCRIPTION
cargo build output:
```rust
warning: use of deprecated associated function `image::DynamicImage::to_bgra`: replaced by `to_bgra8`
   --> src/rendering/blocks/image_block.rs:137:26
    |
137 |                         .to_bgra() // Cairo reads pixels back-to-front, so ARgb32 is actually BgrA32.
    |                          ^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default
```