### PR TITLE
AUR: add wired-bin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: build
+
+on: [ push ]
+
+jobs:
+  wired:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Restore cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libdbus-1-dev libcairo-dev libpango1.0-dev libglib2.0-dev \
+            libx11-dev libxss-dev rustc cargo pkg-config
+
+      - name: Build wired-notify
+        run: cargo build --release
+
+      - name: Create tarball
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          mkdir -p bin
+          cp target/release/wired bin/
+          VERSION=$(./bin/wired --version)
+          tar -czf "wired_${VERSION}_x86_64.tar.gz" \
+            bin/wired LICENSE
+
+      - name: Release tarball
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: wired_*_x86_64.tar.gz
+
+      - name: SHA256 Hash
+        if: startsWith(github.ref, 'refs/tags/')
+        run: sha256sum wired_*_x86_64.tar.gz

--- a/aur/wired-bin/PKGBUILD
+++ b/aur/wired-bin/PKGBUILD
@@ -1,0 +1,24 @@
+# Maintainer: Toqoz <https://github.com/Toqozz/wired-notify>
+
+pkgname=wired-bin
+pkgver=0.10.3
+pkgrel=1
+pkgdesc="Lightweight notification daemon with highly customizable layout blocks, written in Rust."
+arch=('x86_64')
+url="https://github.com/Toqozz/wired-notify"
+license=('MIT')
+depends=('dbus' 'cairo' 'pango' 'glib2' 'libx11' 'libxss')
+provides=('wired')
+conflicts=('wired')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/Toqozz/wired-notify/releases/download/${pkgver}/wired_${pkgver}_x86_64.tar.gz")
+sha256sums=('3de75596b13ba3950ddafbb95b8575a38664b19ce9a6592dda59d458c13e4834')
+
+package() {
+    cd "${srcdir}"
+
+    # Install binary.
+    install -Dm 755 "bin/wired" "${pkgdir}/usr/bin/wired"
+
+    # Install MIT license
+    install -Dm 644 LICENSE "${pkgdir}/usr/share/licenses/wired/LICENSE-MIT"
+}


### PR DESCRIPTION
* Closes #77 

Before adding the package to AUR, you must release a new version (0.10.3) to build the binary, comments welcome!