### PR TITLE
fix: only get active monitor when necessary

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -162,8 +162,11 @@ pub struct Config {
     #[serde(default)]
     pub shortcuts: ShortcutsConfig,
 
-    #[serde(skip)]
-    pub layouts: Vec<LayoutBlock>,
+    #[serde(skip)] // derived from user settings
+    pub(crate) layouts: Vec<LayoutBlock>,
+
+    #[serde(skip)] // derived from user settings
+    pub(crate) is_auto_active_monitor: bool,
 }
 
 impl Config {
@@ -401,6 +404,8 @@ impl Config {
         if !blocks.is_empty() && config.debug {
             eprintln!("There were {} blocks remaining after creating the layout tree.  Something must be wrong here.", blocks.len());
         }
+
+        config.is_auto_active_monitor = config.layouts.iter().any(|layout| layout.as_notification_block().monitor < 0);
 
         Ok(config)
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -545,11 +545,11 @@ impl NotifyWindowManager {
 fn get_active_monitor(base_window: &winit::window::Window) -> Option<MonitorHandle> {
     let cfg = Config::get();
     if cfg.is_auto_active_monitor {
- match cfg.focus_follows {
+        match cfg.focus_follows {
             FollowMode::Mouse => maths_utility::get_active_monitor_mouse(&base_window),
             FollowMode::Window => maths_utility::get_active_monitor_keyboard(&base_window),
         }
-  } else {
+    } else {
         None
     }
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -558,7 +558,7 @@ fn get_active_monitor(base_window: &winit::window::Window) -> Option<MonitorHand
 // The root block is handled differently.
 // If the root block doesn't meet criteria, then don't draw at all.
 // If the root block does meet criteria, but no child blocks do, then don't draw.
-pub fn notification_meets_layout_criteria(root: &LayoutBlock, notification: &Notification) -> bool {
+fn notification_meets_layout_criteria(root: &LayoutBlock, notification: &Notification) -> bool {
     // Root block handled differently to be more intuitive.
     if !root.should_draw(notification) {
         return false;

--- a/src/maths_utility.rs
+++ b/src/maths_utility.rs
@@ -590,7 +590,7 @@ pub fn query_screensaver_info(base_window: &Window) -> Result<XScreenSaverInfo, 
     }
 }
 
-pub fn get_mouse_pos(base_window: &Window) -> (i32, i32) {
+fn get_mouse_pos(base_window: &Window) -> (i32, i32) {
     // Christ this feels expensive, but it's probably fine.
     let display = base_window.xlib_display().unwrap();
 
@@ -641,7 +641,7 @@ pub fn get_active_monitor_mouse(base_window: &Window) -> Option<MonitorHandle> {
     None
 }
 
-pub fn get_active_window_rect(base_window: &Window) -> Option<Rect> {
+fn get_active_window_rect(base_window: &Window) -> Option<Rect> {
     let display = base_window.xlib_display().unwrap();
     let mut focus_win: x11::xlib::Window = 0;
 


### PR DESCRIPTION
- relates to https://github.com/Toqozz/wired-notify/issues/47
- slow down period of monitor and idle dirtiness check from 0.33sec to 1.0sec when no layouts require automatic selection of output monitor
- don't check mouse position or keyboard focus at all when no layouts require automatic selection of output monitor
- this is a stepping stone to unlocking wayland functionality without requiring us to fix everything all at once