### PR TITLE
chore: set toolchain, fix warnings

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+# https://github.com/rust-lang/rustup/blob/master/doc/src/overrides.md#the-toolchain-file
+
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]

--- a/src/bus/dbus.rs
+++ b/src/bus/dbus.rs
@@ -226,6 +226,7 @@ pub enum Message {
     Notify(Notification),
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Clone)]
 pub enum ImageData {
     SVG(Vec<u8>),
@@ -354,7 +355,7 @@ impl Notification {
             //dbg!(end - start);
 
             // Fall back to trying to open with image-rs.
-            maybe_image.or(image::open(path).ok().map(|d| ImageData::Dynamic(d)))
+            maybe_image.or_else(|| image::open(path).ok().map(ImageData::Dynamic))
         }
 
         fn image_from_data(data: &VecDeque<Box<dyn RefArg>>) -> Option<ImageData> {
@@ -384,7 +385,7 @@ impl Notification {
                 return None;
             }
 
-            let x = match channels {
+            match channels {
                 3 => ImageBuffer::from_raw(width as u32, height as u32, bytes)
                     .map(|buf| ImageData::Dynamic(DynamicImage::ImageRgb8(buf))),
                 4 => ImageBuffer::from_raw(width as u32, height as u32, bytes)
@@ -393,12 +394,7 @@ impl Notification {
                     eprintln!("Unsupported hint image format!  Couldn't load hint image.");
                     None
                 }
-            };
-
-            //let end = std::time::Instant::now();
-            //dbg!(end - start);
-
-            x
+            }
         }
 
         let app_image = image_from_path(&app_icon);
@@ -461,7 +457,7 @@ impl Notification {
             id,
             tag,
             note,
-            app_name: app_name.to_owned(),
+            app_name,
             summary,
             body,
             actions: actions_map,

--- a/src/bus/dbus_codegen.rs
+++ b/src/bus/dbus_codegen.rs
@@ -6,6 +6,7 @@ use dbus_crossroads as crossroads;
 
 pub trait OrgFreedesktopNotifications {
     fn get_capabilities(&mut self) -> Result<Vec<String>, dbus::MethodErr>;
+    #[allow(clippy::too_many_arguments)]
     fn notify(
         &mut self,
         app_name: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,12 +55,12 @@ impl CLIListener {
         Ok(CLIListener { listener })
     }
 
-    pub fn process_messages(&self, mut manager: &mut NotifyWindowManager, el: &EventLoopWindowTarget<()>) {
+    pub fn process_messages(&self, manager: &mut NotifyWindowManager, el: &EventLoopWindowTarget<()>) {
         // Since we're non-blocking, mostly this is just std::io::ErrorKind::WouldBlock.
         // For other errors, we should probably inform users to aide debugging.
         // I don't love the idea of spamming stderr here, however.
         match self.listener.accept() {
-            Ok((socket, _addr)) => match handle_socket_message(&mut manager, el, socket) {
+            Ok((socket, _addr)) => match handle_socket_message(manager, el, socket) {
                 Ok(_) => (),
                 Err(e) => eprintln!("Error while handling socket message: {:?}", e),
             },
@@ -115,7 +115,7 @@ pub fn handle_socket_message(
         };
 
         println!("Received socket message: {}", line);
-        if let Some((command, args)) = line.split_once(":") {
+        if let Some((command, args)) = line.split_once(':') {
             match command {
                 "drop" => {
                     if args == "all" {
@@ -127,7 +127,7 @@ pub fn handle_socket_message(
                 }
                 "action" => {
                     let (notif_id, action_id) = args
-                        .split_once(",")
+                        .split_once(',')
                         .ok_or(CLIError::Parse("Malformed action request."))?;
 
                     let id = get_window_id(notif_id, manager)?;
@@ -273,7 +273,7 @@ pub fn process_cli(args: Vec<String>) -> Result<ShouldRun, String> {
         }
 
         if let Some(to_action) = matches.opt_str("a") {
-            let (notification, action) = match to_action.split_once(":") {
+            let (notification, action) = match to_action.split_once(':') {
                 Some(na) => na,
                 None => {
                     return Err("Missing ':' in action argument.\n\

--- a/src/config.rs
+++ b/src/config.rs
@@ -362,7 +362,7 @@ impl Config {
         let mut roots: Vec<LayoutBlock> = vec![];
         let mut i = 0;
         while i < blocks.len() {
-            if blocks[i].parent == "" {
+            if blocks[i].parent.is_empty() {
                 roots.push(blocks.swap_remove(i));
             } else {
                 i += 1;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -123,7 +123,7 @@ impl NotifyWindowManager {
             }
         }
 
-        if maybe_windows.len() > 0 {
+        if !maybe_windows.is_empty() {
             for w in maybe_windows {
                 w.replace_notification(notification.clone());
             }
@@ -542,7 +542,7 @@ impl NotifyWindowManager {
     }
 
     pub fn has_windows(&self) -> bool {
-        self.layout_windows.values().any(|m| m.len() > 0)
+        self.layout_windows.values().any(|m| !m.is_empty())
     }
 
     pub fn is_idle_1s(&self) -> bool {
@@ -563,8 +563,8 @@ fn maybe_get_active_monitor(base_window: &winit::window::Window) -> Option<Monit
     let cfg = Config::get();
     if cfg.is_auto_active_monitor {
         match cfg.focus_follows {
-            FollowMode::Mouse => maths_utility::get_active_monitor_mouse(&base_window),
-            FollowMode::Window => maths_utility::get_active_monitor_keyboard(&base_window),
+            FollowMode::Mouse => maths_utility::get_active_monitor_mouse(base_window),
+            FollowMode::Window => maths_utility::get_active_monitor_keyboard(base_window),
         }
     } else {
         None

--- a/src/maths_utility.rs
+++ b/src/maths_utility.rs
@@ -633,7 +633,7 @@ pub fn get_active_monitor_mouse(base_window: &Window) -> Option<MonitorHandle> {
             pos.x.into(), pos.y.into(), size.width.into(), size.height.into()
         );
 
-        if rect.contains_point(&mouse_pos) {
+        if rect.contains_point(mouse_pos) {
             return Some(monitor);
         }
     }
@@ -723,7 +723,7 @@ pub fn get_active_monitor_keyboard(base_window: &Window) -> Option<MonitorHandle
     handle
 }
 
-pub fn svg_to_pixels(data: &Vec<u8>, width: u32, height: u32) -> Option<Vec<u8>> {
+pub fn svg_to_pixels(data: &[u8], width: u32, height: u32) -> Option<Vec<u8>> {
     use usvg::{Tree, Options, FitTo};
     use tiny_skia::{Pixmap, Transform};
 
@@ -735,7 +735,7 @@ pub fn svg_to_pixels(data: &Vec<u8>, width: u32, height: u32) -> Option<Vec<u8>>
     */
 
     let opt = Options::default();
-    let tree = Tree::from_data(&data, &opt.to_ref()).ok()?;
+    let tree = Tree::from_data(data, &opt.to_ref()).ok()?;
     let mut pixmap = Pixmap::new(width, height)?;
     resvg::render(
         &tree,
@@ -755,13 +755,11 @@ pub fn svg_to_pixels(data: &Vec<u8>, width: u32, height: u32) -> Option<Vec<u8>>
     //Some(image::DynamicImage::ImageRgba8(img))
 }
 
-pub fn rgba_to_bgra(pixels: &mut Vec<u8>, width: u32, height: u32) {
+pub fn rgba_to_bgra(pixels: &mut [u8], width: u32, height: u32) {
     let mut offset = 0;
     for _y in 0..height {
         for _x in 0..width {
-            let temp = pixels[offset];
-            pixels[offset] = pixels[offset + 2];
-            pixels[offset + 2] = temp;
+            pixels.swap(offset, offset + 2);
 
             // g and a are in the same position.
             //pixels[offset + 1] = pixels[offset + 1];

--- a/src/rendering/blocks/image_block.rs
+++ b/src/rendering/blocks/image_block.rs
@@ -82,7 +82,7 @@ impl DrawableLayoutElement for ImageBlockParameters {
             rect.set_xy(pos.x, pos.y);
 
             let (x, y) = (pos.x + self.padding.left, pos.y + self.padding.top);
-            window.context.set_source_surface(&img_sfc, x, y)?;
+            window.context.set_source_surface(img_sfc, x, y)?;
             maths_utility::cairo_path_rounded_rectangle(
                 &window.context,
                 x,
@@ -126,12 +126,12 @@ impl DrawableLayoutElement for ImageBlockParameters {
                 .notification
                 .app_image
                 .as_ref()
-                .or_else(|| window.notification.hint_image.as_ref()),
+                .or(window.notification.hint_image.as_ref()),
             ImageType::HintThenApp => window
                 .notification
                 .hint_image
                 .as_ref()
-                .or_else(|| window.notification.app_image.as_ref()),
+                .or(window.notification.app_image.as_ref()),
         };
 
         let maybe_pixels = if let Some(data) = maybe_image_data {

--- a/src/rendering/layout.rs
+++ b/src/rendering/layout.rs
@@ -92,10 +92,10 @@ impl LayoutBlock {
             match criteria {
                 RenderCriteria::Summary => !notification.summary.is_empty(),
                 RenderCriteria::Body => !notification.body.is_empty(),
-                RenderCriteria::AppImage => !notification.app_image.is_none(),
-                RenderCriteria::HintImage => !notification.hint_image.is_none(),
+                RenderCriteria::AppImage => notification.app_image.is_some(),
+                RenderCriteria::HintImage => notification.hint_image.is_some(),
                 RenderCriteria::AppName(name) => notification.app_name.eq(name),
-                RenderCriteria::Progress => !notification.percentage.is_none(),
+                RenderCriteria::Progress => notification.percentage.is_some(),
                 RenderCriteria::Urgency(u) => match notification.urgency {
                     Urgency::Low => u.eq("low"),
                     Urgency::Normal => u.eq("normal"),
@@ -103,8 +103,8 @@ impl LayoutBlock {
                 },
                 RenderCriteria::Tag(t) => notification.tag.as_ref().eq(&Some(t)),
                 RenderCriteria::Note(n) => notification.note.as_ref().eq(&Some(n)),
-                RenderCriteria::ActionDefault => !notification.get_default_action().is_none(),
-                RenderCriteria::ActionOther(i) => !notification.get_other_action(*i).is_none(),
+                RenderCriteria::ActionDefault => notification.get_default_action().is_some(),
+                RenderCriteria::ActionOther(i) => notification.get_other_action(*i).is_some(),
 
                 RenderCriteria::And(criterion) => logic_matches(Logic::And, criterion, notification),
                 RenderCriteria::Or(criterion) => logic_matches(Logic::Or, criterion, notification),
@@ -224,11 +224,9 @@ impl LayoutBlock {
         // right?
         let (rect, acc_rect) = {
             let rect = if self.should_draw(&window.notification) {
-                let rect = self
-                    .params
+                self.params
                     .draw(&self.hook, &self.offset, parent_rect_fixed, window)
-                    .expect("Invalid cairo surface state.");
-                rect
+                    .expect("Invalid cairo surface state.")
             } else {
                 // If block shouldn't be rendered, then we should be safe to just return an
                 // empty rect.
@@ -346,7 +344,7 @@ impl LayoutBlock {
 
     pub fn as_notification_block(&self) -> &NotificationBlockParameters {
         if let LayoutElement::NotificationBlock(p) = &self.params {
-            return p;
+            p
         } else {
             panic!("Tried to cast a LayoutBlock as type NotificationBlock when it was something else.");
         }

--- a/src/rendering/window.rs
+++ b/src/rendering/window.rs
@@ -174,7 +174,7 @@ impl NotifyWindow {
                 update_mode = UpdateModes::DRAW;
             }
         }
-        if cfg.notifications_spawn_paused && !(!manager.is_idle_1s() && cfg.unpause_on_input) {
+        if (!cfg.unpause_on_input || manager.is_idle_1s()) && cfg.notifications_spawn_paused {
             update_mode = UpdateModes::DRAW;
         }
 


### PR DESCRIPTION
- I ran `cargo clippy --all -- -D clippy::all` and fixed all of the warnings
- I decided not to make this part of the GitHub workflow just yet, as my previous addition (mandatory `cargo fmt`) caused some toil for @Toqozz and I'd like to earn back some trust first :)
- I did manually test this with some notifications with and without icons, nothing seemed to explode :)