### PR TITLE
Dynamic monitor switching?

### DIFF
--- a/src/bus/dbus.rs
+++ b/src/bus/dbus.rs
@@ -239,6 +239,8 @@ pub struct Notification {
     pub tag: Option<String>,
     pub note: Option<String>,
 
+    pub monitor: Option<String>,
+
     pub app_name: String,
 
     pub summary: String,
@@ -283,6 +285,7 @@ impl Notification {
             id,
             tag: None,
             note: None,
+            monitor: None,
             app_name: "Wired".to_owned(),
             summary: summary.to_owned(),
             body: body.to_owned(),
@@ -438,6 +441,9 @@ impl Notification {
         let tag = arg::prop_cast::<String>(&hints, "wired-tag").cloned();
         let note = arg::prop_cast::<String>(&hints, "wired-note").cloned();
 
+        // Allow overriding the monitor through a hint, used for scripts.
+        let monitor = arg::prop_cast::<String>(&hints, "wired-monitor").cloned();
+
         let percentage: Option<f32>;
         if let Some(value) = arg::prop_cast::<i32>(&hints, "value") {
             // This should be ok since we only support values from 0 to 100.
@@ -457,6 +463,7 @@ impl Notification {
             id,
             tag,
             note,
+            monitor,
             app_name,
             summary,
             body,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -260,6 +260,7 @@ impl NotifyWindowManager {
             let (pos, size) = (monitor.position(), monitor.size());
             let monitor_rect = Rect::new(pos.x.into(), pos.y.into(), size.width.into(), size.height.into());
             let mut prev_rect = monitor_rect;
+            let mut last_mon = monitor;
 
             let mut real_idx = 0;
             for window in windows {
@@ -267,6 +268,42 @@ impl NotifyWindowManager {
                 // will be less noticeable.
                 if window.marked_for_destroy {
                     continue;
+                }
+
+                // Testing individual notification monitor overrides:
+                // This is not the right way to handle this IMO, but it works.
+                // Ideally, creating a notification with a monitor override would
+                // actually create a new layout/window for that stack of notifications
+                // on that monitor. We could do this statically by defining RenderCriteria
+                // for each monitor, but that wouldn't actually scale dynamically with an
+                // arbitrary number of monitors. It also would mean duplicating entire
+                // layout stacks, at least until templates become an option, which still
+                // wouldn't completely solve the issue, but would make it better.
+                if window.notification.monitor.is_some() {
+                    let maybe_monitor2 = self
+                    .base_window
+                    .available_monitors()
+                    .nth(window
+                        .notification
+                        .monitor
+                        .as_ref()
+                        .unwrap()
+                        .parse::<i8>()
+                        .unwrap() as usize
+                    );
+
+                    if maybe_monitor2.is_some() {
+                        let new_mon = maybe_monitor2.unwrap();
+                        if last_mon != new_mon {
+                            let new_rect = Rect::new(
+                                new_mon.position().x.into(), 
+                                new_mon.position().y.into(), 
+                                new_mon.size().width.into(), 
+                                new_mon.size().height.into());
+                            prev_rect = new_rect;
+                            last_mon = new_mon;
+                        }
+                    }
                 }
 
                 let mut window_rect = window.get_inner_rect();


### PR DESCRIPTION
I really like wired, particularly because it allows me to create system alerts for actions on bspwm, and because each notification (or each layout) is it's own window, I can create layouts in the center of my screen, at the bottom, or whatever. However, one big limitation that I am finding is that the configuration of these layouts is not, and really can not ever be dynamic. When I want to create a popup through a script, I have to have a layout for that popup, which most of the time is fine. However, as I found with certain setups like multi-monitor, it just doesn't scale. Yes, you have focus follows mouse/active window, but I have found that this doesn't actually work with bspwm, and probably most other wms, if you are, say for example, making a popup every time you shift to a new workspace on a specific monitor. You can't use mouse focus, because the mouse could be anywhere, and you can't rely on active window, because if you switch to a workspace without a window, the notification will flicker for a second, then shoot over to the default monitor.
For proper script use, it would be great to have a way to specify overrides for certain config options that are likely to need to be dynamic. This is one such example. Admittedly, this is far from a perfect solution. Disclaimer, I am not a rust developer, but I'm trying to learn! The biggest issue with my proposed solution here is that I would actually prefer if when a new notification was created along with an override for the monitor, that a new layout/window for that new location be dynamically created, allowing for the two stacks of notifications to be independent from each other. This would be mitigated by having templates, but you would still have to have a separate layout for each monitor, and set some kind of rendercriteria for each. It would work, but not especially great for systems that might have a changing number of monitors attached. It doesn't scale. 
Like I said, this is far from a perfect solution, and I am only personally using it as a temporary stop gap until something more robust can be implemented, but I wanted to actually provide a working example instead of just opening a ticket with my complaints :stuck_out_tongue: . Some guidance on whether or not dynamically creating new layouts based on hint would even be possible with the current system would be great, although I suspect it would be quite difficult because based on my 10 minutes of code reading it seems the layouts and windows are generated before notifications are received, so you would need some way to read a notification as it comes in, then go back up the lifecycle to create a new layout/window, then move forward? I haven't quite figured out how wireds lifecylcle works. If this would be possible, I think it would be very worth exploring. Not for every config option, but at least for things as dynamic as monitors.