### PR TITLE
nix: use string instead of url literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To use it in another flake:
 ```nix
 {
   inputs = {
-    wired.url = github:Toqozz/wired-notify;
+    wired.url = "github:Toqozz/wired-notify";
   };
 }
 ```
@@ -89,8 +89,8 @@ For example, to install it for all users in NixOS:
 ```nix
 {
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
-    wired.url = github:Toqozz/wired-notify;
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    wired.url = "github:Toqozz/wired-notify";
   };
   outputs = { self, nixpkgs, wired }: let
     std = nixpkgs.lib;

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,14 @@
   description = "Lightweight notification daemon with highly customizable layout blocks, written in Rust.";
 
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
-    utils.url = github:numtide/flake-utils;
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    utils.url = "github:numtide/flake-utils";
     naersk = {
-      url = github:nix-community/naersk;
+      url = "github:nix-community/naersk";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     alejandra = {
-      url = github:kamadorueda/alejandra;
+      url = "github:kamadorueda/alejandra";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -5,7 +5,6 @@
   ...
 }:
 with builtins; let
-  std = pkgs.lib;
   cfg = config.services.wired;
 in {
   options.services.wired = with lib; {
@@ -38,7 +37,7 @@ in {
           ExecStart = "${cfg.package}/bin/wired";
         };
         Install = {
-          WantedBy = [ "graphical-session.target" ];
+          WantedBy = ["graphical-session.target"];
         };
       };
     })


### PR DESCRIPTION
I changed the URL literal to a string according to the [45 RFC](https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md)

Also removed unused variable `std`