### PR TITLE
Improve systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The recommended way to start Wired is just to put the following in your autostar
 /path/to/wired &
 ```
 
-There is also a `wired.service` file in the root of the repository if you want to use systemd. Just copy it to `usr/local/lib/systemd/system` (or your distro equivalent) and run:
+There is also a `wired.service` file in the root of the repository if you want to use systemd. Just copy it to `/usr/local/lib/systemd/user/wired.service` (or your distro equivalent) and run:
 ```
 $ systemctl enable --now --user wired.service
 ```

--- a/wired.service
+++ b/wired.service
@@ -1,11 +1,14 @@
 [Unit]
 Description=Wired Notification Daemon
-PartOf=graphical-session.target
+Documentation=https://github.com/Toqozz/wired-notify
+After=graphical.target
 
 [Service]
 Type=dbus
 BusName=org.freedesktop.Notifications
 ExecStart=/usr/bin/wired
+Restart=always
+RestartSec=10
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=default.target


### PR DESCRIPTION
With the `wired.service` I had issues, that it would not start automatically on login to the session.
This PR changes the install target, as well as the starting condition so it hopefully gets started on any system.
I am not an expert in systemd, so if there is still improvement I am happy to adopt any suggestion.

Also added a little bit of info to the unit file and updated the `README.md`
