### PR TITLE
nix: fix build on latest nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652840887,
-        "narHash": "sha256-gEK4NNa4GwIgTZE63kt/4WTFAWRTJVSa30+h4ZjFh9U=",
+        "lastModified": 1665723124,
+        "narHash": "sha256-J1JY2cN0L+CNDSrGkNdbiTl2EFV8hpqqsDJFICsYSBw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "52dc75a4fee3fdbcb792cb6fba009876b912bfe0",
+        "rev": "31d567846255e122846548255101980162bbf641",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
       dlib,
       cairo,
       pango,
-      pkgconfig,
+      pkg-config,
       xorg,
       ...
     }:
@@ -48,7 +48,7 @@
 
         # Requires dbus cairo and pango
         # pkgconfig, glib and xorg are required for x11-crate
-        nativeBuildInputs = [pkgconfig];
+        nativeBuildInputs = [pkg-config];
         buildInputs = [
           dbus
           dlib


### PR DESCRIPTION
- updated `nixpkgs` version in the flake lock file.
- fixed error: 'pkgconfig' has been renamed to/replaced by 'pkg-config'
