### PR TITLE
feat: add `Not(criterion)` render criterion to allow for more complex logic

### DIFF
--- a/src/rendering/layout.rs
+++ b/src/rendering/layout.rs
@@ -55,6 +55,7 @@ pub enum RenderCriteria {
 
     And(Vec<RenderCriteria>),
     Or(Vec<RenderCriteria>),
+    Not(Box<RenderCriteria>),
 }
 
 enum Logic {
@@ -108,6 +109,7 @@ impl LayoutBlock {
 
                 RenderCriteria::And(criterion) => logic_matches(Logic::And, criterion, notification),
                 RenderCriteria::Or(criterion) => logic_matches(Logic::Or, criterion, notification),
+                RenderCriteria::Not(criterion) => !criteria_matches(criterion, notification),
             }
         }
 


### PR DESCRIPTION
Due to the split of negative render criterions as a separate configuration value (`render_criterions` and `render_anti_criterions`), there are some combinations of expressions that cannot be represented.

One example is `Or(AppImage, Not(AppName(""), AppName("notify-send"))`, i.e. render if there is an app image or an app name that isn't one of those specified. This useful because it allows me to introduce a top bar that is only present if necessary, but cannot be represented currently because both `render_criterions` and `render_anti_criterions` would require a `Not(x)`.

This tiny PR adds this simple expression and thus allows representation of any propositional logic formula. This also technically removes the need for render_anti_criterions, because everything can be written as a render criterion, but keeping it doesn't hurt either.