### PR TITLE
fix explanation from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This flake also provides a module for [home-manager](https://github.com/nix-comm
     in home-manager.lib.homeManagerConfiguration {
       pkgs = import nixpkgs {
         inherit system;
-        overlays = [ wired.overlays.${system} ];
+        overlays = [ wired.overlays.default ];
       };
 
       modules = [


### PR DESCRIPTION
As explained [here](https://github.com/Toqozz/wired-notify/issues/115#issuecomment-1743992531) the explanation in the README is fixed