### PR TITLE
Improve flake

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,22 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "Update flake.lock"
+          pr-labels: |
+            dependencies
+            automated
+          pr-reviewers: TornaxO7

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,3 @@
+(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
+  src = builtins.fetchGit ./.;
+}).defaultNix

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,0 @@
-(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
-  src = builtins.fetchGit ./.;
-}).defaultNix

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,3 @@
 (import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
   src = builtins.fetchGit ./.;
-})
-.defaultNix
+}).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -2,22 +2,45 @@
   "nodes": {
     "alejandra": {
       "inputs": {
+        "fenix": "fenix",
         "flakeCompat": "flakeCompat",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1652974241,
-        "narHash": "sha256-0AolxQtKj3Oek0WSbODDpPVO5Ih8PXHOA3qXEKPB4dQ=",
+        "lastModified": 1694541876,
+        "narHash": "sha256-lStDIPizbJipd1JpNKX1olBKzyIosyC2U/mVFwJPcZE=",
         "owner": "kamadorueda",
         "repo": "alejandra",
-        "rev": "0be1462419fc73270a5dc0f84f8092603890b029",
+        "rev": "e53c2c6c6c103dc3f848dbd9fbd93ee7c69c109f",
         "type": "github"
       },
       "original": {
         "owner": "kamadorueda",
         "repo": "alejandra",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "alejandra",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1668234453,
+        "narHash": "sha256-FmuZThToBvRsqCauYJ3l8HJoGLAY5cMULeYEKIaGrRw=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "8f219f6b36e8d0d56afa7f67e6e3df63ef013cdb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
         "type": "github"
       }
     },
@@ -42,11 +65,11 @@
     "flakeCompat": {
       "flake": false,
       "locked": {
-        "lastModified": 1648199409,
-        "narHash": "sha256-JwPKdC2PoVBkG6E+eWw3j6BMR6sL3COpYWfif7RVb8Y=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "64a525ee38886ab9028e6f61790de0832aa3ef03",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
@@ -57,11 +80,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665723124,
-        "narHash": "sha256-J1JY2cN0L+CNDSrGkNdbiTl2EFV8hpqqsDJFICsYSBw=",
+        "lastModified": 1702539185,
+        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "31d567846255e122846548255101980162bbf641",
+        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
         "type": "github"
       },
       "original": {
@@ -93,6 +116,23 @@
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "systems": "systems_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668182250,
+        "narHash": "sha256-PYGaOCiFvnJdVz+ZCaKF8geGdffXjJUNcMwaBHv0FT4=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "45ec315e01dc8dd1146dfeb65f0ef6e5c2efed78",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "rust-overlay": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,46 +1,20 @@
 {
   "nodes": {
-    "alejandra": {
+    "flake-parts": {
       "inputs": {
-        "fenix": "fenix",
-        "flakeCompat": "flakeCompat",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1694541876,
-        "narHash": "sha256-lStDIPizbJipd1JpNKX1olBKzyIosyC2U/mVFwJPcZE=",
-        "owner": "kamadorueda",
-        "repo": "alejandra",
-        "rev": "e53c2c6c6c103dc3f848dbd9fbd93ee7c69c109f",
+        "lastModified": 1704152458,
+        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "88a2cd8166694ba0b6cb374700799cec53aef527",
         "type": "github"
       },
       "original": {
-        "owner": "kamadorueda",
-        "repo": "alejandra",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "alejandra",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1668234453,
-        "narHash": "sha256-FmuZThToBvRsqCauYJ3l8HJoGLAY5cMULeYEKIaGrRw=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "8f219f6b36e8d0d56afa7f67e6e3df63ef013cdb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -62,22 +36,6 @@
         "type": "github"
       }
     },
-    "flakeCompat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1702539185,
@@ -90,6 +48,24 @@
       "original": {
         "owner": "nixos",
         "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -112,27 +88,9 @@
     },
     "root": {
       "inputs": {
-        "alejandra": "alejandra",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "systems": "systems_2"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1668182250,
-        "narHash": "sha256-PYGaOCiFvnJdVz+ZCaKF8geGdffXjJUNcMwaBHv0FT4=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "45ec315e01dc8dd1146dfeb65f0ef6e5c2efed78",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
@@ -155,21 +113,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flakeCompat": {
       "flake": false,
       "locked": {
@@ -53,25 +71,76 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1681358109,
+        "narHash": "sha256-eKyxW4OohHQx9Urxi7TQlFBTDWII+F+x2hklDOQPB50=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "96ba1c52e54e74c3197f4d43026b3f3d92e83ff9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "alejandra": "alejandra",
         "nixpkgs": "nixpkgs",
-        "utils": "utils"
+        "rust-overlay": "rust-overlay",
+        "systems": "systems_2"
       }
     },
-    "utils": {
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
       "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "lastModified": 1702865809,
+        "narHash": "sha256-K7caQe+KqjqTBFmJawmBjmm25S6bza5CXhAqbXFLyH8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "b2aafcee4a8842cecfc877ff7dd271f333dc0fa8",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,129 +3,108 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    systems.url = "github:nix-systems/default";
     rust-overlay.url = "github:oxalica/rust-overlay";
-    alejandra = {
-      url = "github:kamadorueda/alejandra";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs =
-    { self
-    , nixpkgs
-    , systems
-    , alejandra
-    , rust-overlay
-    , ...
-    }:
-    let
-      inherit (builtins) fromTOML readFile substring mapAttrs;
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
 
-      eachSystem = nixpkgs.lib.genAttrs (import systems);
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
 
-      cargoToml = fromTOML (readFile ./Cargo.toml);
-      version = "${cargoToml.package.version}_${substring 0 8 self.lastModifiedDate}_${self.shortRev or "dirty"}";
-
-      mkWired =
-        { lib
-        , rustPlatform
-        , dbus
-        , dlib
-        , cairo
-        , pango
-        , pkg-config
-        , xorg
-        , ...
-        }:
-        rustPlatform.buildRustPackage {
-          name = "wired-${version}";
-
-          src = lib.cleanSource ./.;
-          cargoLock.lockFile = ./Cargo.lock;
-
-          # Requires dbus cairo and pango
-          # pkgconfig, glib and xorg are required for x11-crate
-          nativeBuildInputs = [ pkg-config ];
-          buildInputs = [
-            dbus
-            dlib
-            cairo
-            pango
-            xorg.libX11
-            xorg.libXi
-            xorg.libXrandr
-            xorg.libXcursor
-            xorg.libXScrnSaver
-          ];
-          # install extra files (i.e. the systemd service)
-          postInstall = ''
-            # /usr/bin/wired doesn't exist, here, because the binary will be somewhere in /nix/store,
-            # so this fixes the bin path in the systemd service and writes the updated file to the output dir.
-            mkdir -p $out/usr/lib/systemd/system
-            substitute ./wired.service $out/usr/lib/systemd/system/wired.service --replace /usr/bin/wired $out/bin/wired
-            # install example/default config files to etc/wired -- Arch packages seem to use etc/{pkg} for this,
-            # so there's precedent
-            install -Dm444 -t $out/etc/wired wired.ron wired_multilayout.ron
-          '';
-
-          meta = {
-            homepage = "https://github.com/Toqozz/wired-notify";
-            downloadPage = "https://github.com/Toqozz/wired-notify/releases";
-            license = lib.licenses.mit;
-          };
-        };
-    in
-    {
-      # `nix fmt` (added in Nix 2.8)
-      # (generating this outside of `eachDefaultSystem` because alejandra's supported systems may not match ours)
-      formatter = mapAttrs (system: pkgs: pkgs.default) alejandra.packages;
-
-      # consumed by github:nix-community/home-manager
-      homeManagerModules.default = import ./home-manager.nix;
-
-      overlays = {
-        default = final: prev: {
-          wired = prev.callPackage mkWired { };
-        };
+      flake = {
+        homeManagerModules.default = import ./home-manager.nix;
       };
 
-      packages = eachSystem (system:
+      perSystem = { self', system, pkgs, ... }:
         let
-          pkgs = import nixpkgs {
-            inherit system;
-          };
+          inherit (builtins) fromTOML readFile;
+
+          cargoToml = fromTOML (readFile ./Cargo.toml);
+          version = "${cargoToml.package.version}";
+          mkWired =
+            { lib
+            , rustPlatform
+            , dbus
+            , dlib
+            , cairo
+            , pango
+            , pkg-config
+            , xorg
+            , ...
+            }:
+            rustPlatform.buildRustPackage {
+              name = "wired-${version}";
+
+              src = lib.cleanSource ./.;
+              cargoLock.lockFile = ./Cargo.lock;
+
+              # Requires dbus cairo and pango
+              # pkgconfig, glib and xorg are required for x11-crate
+              nativeBuildInputs = [ pkg-config ];
+              buildInputs = [
+                dbus
+                dlib
+                cairo
+                pango
+                xorg.libX11
+                xorg.libXi
+                xorg.libXrandr
+                xorg.libXcursor
+                xorg.libXScrnSaver
+              ];
+              # install extra files (i.e. the systemd service)
+              postInstall = ''
+                # /usr/bin/wired doesn't exist, here, because the binary will be somewhere in /nix/store,
+                # so this fixes the bin path in the systemd service and writes the updated file to the output dir.
+                mkdir -p $out/usr/lib/systemd/system
+                substitute ./wired.service $out/usr/lib/systemd/system/wired.service --replace /usr/bin/wired $out/bin/wired
+                # install example/default config files to etc/wired -- Arch packages seem to use etc/{pkg} for this,
+                # so there's precedent
+                install -Dm444 -t $out/etc/wired wired.ron wired_multilayout.ron
+              '';
+
+              meta = {
+                homepage = "https://github.com/Toqozz/wired-notify";
+                downloadPage = "https://github.com/Toqozz/wired-notify/releases";
+                license = lib.licenses.mit;
+                mainProgram = "wired";
+              };
+            };
         in
         {
-          default = pkgs.callPackage mkWired { };
-        });
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = with inputs; [
+              rust-overlay.overlays.default
+            ];
+          };
 
-      apps = eachSystem (system: {
-        default = self.apps.${system}.wired;
+          apps = {
+            default = self'.apps.wired;
 
-        wired = {
-          type = "app";
-          program = "${self.packages.${system}.default}/bin/wired";
+            wired = {
+              type = "app";
+              program = "${pkgs.lib.getExe self'.packages.default}";
+            };
+          };
+
+          packages.default = pkgs.callPackage mkWired { };
+
+          devShells.default =
+            let
+              wired = pkgs.callPackage mkWired { };
+
+              rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
+                extensions = [ "rust-src" "rust-analyzer" ];
+              };
+            in
+            pkgs.mkShell {
+              packages = [ rust-toolchain ] ++ wired.nativeBuildInputs ++ wired.buildInputs;
+            };
         };
-      });
-
-      devShells = eachSystem
-        (system:
-          let
-            pkgs = import nixpkgs {
-              inherit system;
-              overlays = [ rust-overlay.overlays.default ];
-            };
-
-            wired = pkgs.callPackage mkWired { };
-            rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml).override {
-              extensions = [ "rust-src" "rust-analyzer" ];
-            };
-          in
-          {
-            default = pkgs.mkShell {
-              packages = wired.nativeBuildInputs ++ [ rust-toolchain ];
-            };
-          });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,8 @@
             ];
           };
 
+          formatter = pkgs.nixpkgs-fmt;
+
           apps = {
             default = self'.apps.wired;
 

--- a/home-manager.nix
+++ b/home-manager.nix
@@ -1,12 +1,12 @@
-{
-  config,
-  pkgs,
-  lib,
-  ...
+{ config
+, pkgs
+, lib
+, ...
 }:
 with builtins; let
   cfg = config.services.wired;
-in {
+in
+{
   options.services.wired = with lib; {
     enable = mkEnableOption "wired notification daemon";
     package = mkOption {
@@ -23,7 +23,7 @@ in {
   };
   config = lib.mkMerge [
     (lib.mkIf cfg.enable {
-      home.packages = [cfg.package];
+      home.packages = [ cfg.package ];
       # Ideally this would just install the service unit already provided in this repo,
       # but Home Manager doesn't have an idiomatic way to do that as of 2022-05-22
       systemd.user.services."wired" = {
@@ -37,7 +37,7 @@ in {
           ExecStart = "${cfg.package}/bin/wired";
         };
         Install = {
-          WantedBy = ["graphical-session.target"];
+          WantedBy = [ "graphical-session.target" ];
         };
       };
     })

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,0 @@
-(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
-  src = builtins.fetchGit ./.;
-}).shellNix

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,3 @@
 (import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
   src = builtins.fetchGit ./.;
-})
-.shellNix
+}).shellNix

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,10 +110,10 @@ impl ConfigWatcher {
 pub struct Config {
     // Maximum number of notifications to show on screen at once.
     pub max_notifications: usize,
-    pub timeout: i32,               // Default timeout, in milliseconds.
-    pub poll_interval: u64,         // Time between checking for updates, events, drawing, etc.
+    pub timeout: i32,       // Default timeout, in milliseconds.
+    pub poll_interval: u64, // Time between checking for updates, events, drawing, etc.
     #[serde(default = "maths_utility::val_500")]
-    pub idle_poll_interval: u64,    // Same as above, but when no notifications are present.
+    pub idle_poll_interval: u64, // Same as above, but when no notifications are present.
     pub layout_blocks: Vec<LayoutBlock>,
 
     // Optional Properties

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,7 +161,8 @@ fn main() {
                 if manager.has_windows() {
                     *control_flow = ControlFlow::WaitUntil(now + poll_interval);
                 } else {
-                    *control_flow = ControlFlow::WaitUntil(now + Duration::from_millis(Config::get().idle_poll_interval));
+                    *control_flow =
+                        ControlFlow::WaitUntil(now + Duration::from_millis(Config::get().idle_poll_interval));
                 }
             }
 


### PR DESCRIPTION
this makes the flake.nix file a bit more readable in my opinion :)

The changes are:
- Replacing `flake-utils` with [`flake-parts`] because [`flake-parts`] is "syntax-friendlier"
- making use of [`oxalica/rust-overlay`] in order to load the given rust-toolchain
- added weekly CI to keep `flake.lock` up to date
- I'd also volunteer to maintain the `flake.nix`
- updated `flake.lock` with `nix flake update`

@Toqozz 

[`flake-parts`]: https://flake.parts/
[`oxalica/rust-overlay`]: https://github.com/oxalica/rust-overlay