### PR TITLE
Update timeout configuration to match spec

### DIFF
--- a/src/bus/dbus.rs
+++ b/src/bus/dbus.rs
@@ -21,6 +21,7 @@ use serde::Serialize;
 use tiny_skia;
 
 use crate::bus::dbus_codegen::{self, OrgFreedesktopNotifications};
+use crate::config::TimeoutBehavior;
 use crate::maths_utility;
 use crate::Config;
 
@@ -254,7 +255,7 @@ pub struct Notification {
 
     #[serde(serialize_with = "serialize_datetime")]
     pub time: DateTime<Local>,
-    pub timeout: i32,
+    pub timeout: Timeout,
 }
 
 use serde::Serializer;
@@ -270,14 +271,14 @@ impl std::fmt::Debug for Notification {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
             f,
-            "Notification: {{\n\tid: {},\n\tapp_name: {},\n\tsummary: {},\n\tbody: {},\n\tactions: {:?},\n\tapp_image: {},\n\thint_image: {},\n\turgency: {:?},\n\tpercentage: {:?},\n\ttime: {},\n\ttimeout: {}\n}}",
+            "Notification: {{\n\tid: {},\n\tapp_name: {},\n\tsummary: {},\n\tbody: {},\n\tactions: {:?},\n\tapp_image: {},\n\thint_image: {},\n\turgency: {:?},\n\tpercentage: {:?},\n\ttime: {},\n\ttimeout: {:?}\n}}",
             self.id, self.app_name, self.summary, self.body, self.actions, self.app_image.is_some(), self.hint_image.is_some(), self.urgency, self.percentage, self.time, self.timeout,
         )
     }
 }
 
 impl Notification {
-    pub fn from_self(summary: &str, body: &str, timeout: i32) -> Self {
+    pub fn from_self(summary: &str, body: &str, timeout: Timeout) -> Self {
         let id = fetch_id();
         Self {
             id,
@@ -452,15 +453,10 @@ impl Notification {
             percentage = None;
         }
 
-        // This comes from the spec, see https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
-        let timeout = if expire_timeout < 0 {
-            // Use the default
-            Config::get().timeout
-        } else if expire_timeout == 0 {
-            // Never expire
-            i32::MAX
-        } else {
-            expire_timeout
+        let cfg = Config::get();
+        let timeout = match cfg.timeout_behavior {
+            TimeoutBehavior::Legacy => legacy_timeout_behavior(expire_timeout, cfg.timeout),
+            TimeoutBehavior::DBusSpec => dbus_spec_timeout_behavior(expire_timeout, cfg.timeout),
         };
 
         Self {
@@ -497,5 +493,26 @@ impl Notification {
         } else {
             None
         }
+    }
+}
+
+#[derive(Clone, Serialize, Debug)]
+pub enum Timeout {
+    Milliseconds(i32),
+    NeverExpire,
+}
+
+fn legacy_timeout_behavior(timeout: i32, default: i32) -> Timeout {
+    Timeout::Milliseconds(if timeout <= 0 { default } else { timeout })
+}
+
+// This comes from the spec, see https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+fn dbus_spec_timeout_behavior(timeout: i32, default: i32) -> Timeout {
+    if timeout < 0 {
+        Timeout::Milliseconds(default)
+    } else if timeout == 0 {
+        Timeout::NeverExpire
+    } else {
+        Timeout::Milliseconds(timeout)
     }
 }

--- a/src/bus/dbus.rs
+++ b/src/bus/dbus.rs
@@ -452,10 +452,16 @@ impl Notification {
             percentage = None;
         }
 
-        let mut timeout = expire_timeout;
-        if timeout <= 0 {
-            timeout = Config::get().timeout;
-        }
+        // This comes from the spec, see https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html
+        let timeout = if expire_timeout < 0 {
+            // Use the default
+            Config::get().timeout
+        } else if expire_timeout == 0 {
+            // Never expire
+            i32::MAX
+        } else {
+            expire_timeout
+        };
 
         Self {
             id,

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,10 @@ pub struct Config {
     pub idle_poll_interval: u64, // Same as above, but when no notifications are present.
     pub layout_blocks: Vec<LayoutBlock>,
 
+    // How to handle various DBus expire_timeout values
+    #[serde(default)]
+    pub timeout_behavior: TimeoutBehavior,
+
     // Optional Properties
 
     // The threshold before pausing notifications due to being idle.  Unspecified = ignore.
@@ -496,6 +500,20 @@ impl Default for ShortcutsConfig {
             notification_action4_and_close: None,
             notification_interact_and_close: None,
         }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub enum TimeoutBehavior {
+    // Legacy treats zero as 'use config default'
+    Legacy,
+    // DBusSpec treats zero as 'never expire'
+    DBusSpec,
+}
+
+impl Default for TimeoutBehavior {
+    fn default() -> Self {
+        Self::DBusSpec
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use winit::{
     platform::unix::EventLoopExtUnix,
 };
 
-use bus::dbus::{Message, Notification};
+use bus::dbus::{Message, Notification, Timeout};
 use cli::ShouldRun;
 use config::Config;
 use manager::NotifyWindowManager;
@@ -149,7 +149,11 @@ fn main() {
                         poll_interval = Duration::from_millis(Config::get().poll_interval);
                         maybe_print_file = open_print_file();
                         manager.replace_or_spawn(
-                            Notification::from_self("Wired", "Config was reloaded.", 5000),
+                            Notification::from_self(
+                                "Wired",
+                                "Config was reloaded.",
+                                Timeout::Milliseconds(5000),
+                            ),
                             event_loop,
                         );
                     }

--- a/src/rendering/window.rs
+++ b/src/rendering/window.rs
@@ -327,10 +327,9 @@ impl NotifyWindow {
 
     pub fn update(&mut self, delta_time: Duration) -> bool {
         if self.update_mode.contains(UpdateModes::FUSE) {
-            if let Timeout::Milliseconds(fuse) = self.fuse {
-                let new_fuse = fuse - delta_time.as_millis() as i32;
-                self.fuse = Timeout::Milliseconds(new_fuse);
-                if new_fuse <= 0 {
+            if let Timeout::Milliseconds(ref mut fuse) = self.fuse {
+                *fuse -= delta_time.as_millis() as i32;
+                if *fuse <= 0 {
                     // Window will be destroyed after others have been repositioned to replace it.
                     // We can return early because drawing will be discarded anyway.
                     self.marked_for_destroy = true;

--- a/wired.ron
+++ b/wired.ron
@@ -7,6 +7,11 @@
     // 1000ms = 1s.
     timeout: 10000,
 
+    // Treats expire_timeout values of zero as 'never expire', see
+    // https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html for details.
+    // For the original behavior of giving notifications with 'expire_timeout: 0' the default 'timeout' value, use 'Legacy'.
+    timeout_behavior: DBusSpec,
+
     // `poll_interval` decides decides how often (in milliseconds) Wired checks events,
     // draws notifications (if necessary) -- the update loop while any notification is present.
     // Note that when no notifications are present, Wired polls at `idle_poll_interval` instead.


### PR DESCRIPTION
Fixes #131 by changing behavior to:

- Use default for timeouts less than zero
- Never expire for timeouts equal to zero
- Use the timeout otherwise

I built and tested this locally (using `notify-send` and others), it works as expected

Also adds a new `timeout_behavior = {Legacy, DBusSpec}` config option, which defaults to the new behavior. The wiki should probably be updated after this lands as well.
