### PR TITLE
Fix Parse() error

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -135,9 +135,13 @@ pub fn handle_socket_message(
                         .ok_or(CLIError::Parse("Malformed action request."))?;
 
                     let id = get_window_id(notif_id, manager)?;
-                    let action = action_id
-                        .parse::<usize>()
-                        .unwrap_or(0);
+                    let action = match action_id {
+                        "default" => 0,
+                        _ => { action_id
+                            .parse::<usize>()
+                            .map_err(|_| CLIError::Parse("Value is not of type usize."))?
+                        }
+                    };
                     manager.trigger_action_idx(id, action);
                 }
                 "show" => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -137,7 +137,7 @@ pub fn handle_socket_message(
                     let id = get_window_id(notif_id, manager)?;
                     let action = action_id
                         .parse::<usize>()
-                        .map_err(|_| CLIError::Parse("Value is not of type usize."))?;
+                        .unwrap_or(0);
                     manager.trigger_action_idx(id, action);
                 }
                 "show" => {


### PR DESCRIPTION
When `wired --action latest:default` is called, a Parse() error is logged, and the default action is not called. This is because "default" cannot be parsed as a `usize`.

I have fixed it in my local by simply setting the value to `0` whenever parsing fails; however, while this is the simplest solution, I suspect there may be better ways to solve this problem (I don't know rust at all).