### PR TITLE
Fix flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,3 @@
-(import (fetchTarball https://github.com/edolstra/flake-compat/archive/master.tar.gz) {
-  src = builtins.fetchGit ./.;
+(import (fetchTarball "https://github.com/edolstra/flake-compat/archive/v1.1.0.tar.gz") {
+  src = ./.;
 }).defaultNix


### PR DESCRIPTION
Hello,

I have updated `default.nix`. Using `builtins.fetchGit ./.` would fail because the `.git` folder doesn't exist when fetched.

<details>

<summary>previous bad behaviour</summary>

```nix
nix-repl> wired-notify = import (fetchTarball "https://github.com/Toqozz/wired-notify/archive/1632418aa15889343028261663e81d8b5595860e.tar.gz")


nix-repl> wired-notify
fatal: '/nix/store/dvd85sj784iia3g8wjhpmng2k93gqm8c-source' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
warning: could not read HEAD ref from repo at 'file:///nix/store/dvd85sj784iia3g8wjhpmng2k93gqm8c-source', using 'master'
fatal: '/nix/store/dvd85sj784iia3g8wjhpmng2k93gqm8c-source' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
warning: could not update mtime for file '/home/leana/.cache/nix/gitv3/1ikqnmfhk5w1kf6nw1gkk9cwasa8n5b4ax22a8i9xydc39bb8kff/refs/heads/master': changing modification time of '"/home/leana/.cache/nix/gitv3/1ikqnmfhk5w1kf6nw1gkk9cwasa8n5b4ax22a8i9xydc39bb8kff/refs/heads/master"' (using `utimensat`): No such file or directory
fatal: Refusing to point HEAD outside of refs/
warning: could not update cached head 'master' for 'file:///nix/store/dvd85sj784iia3g8wjhpmng2k93gqm8c-source'
error:
       … while calling the 'import' builtin
         at «string»:1:2:
            1|  import (fetchTarball "https://github.com/Toqozz/wired-notify/archive/1632418aa15889343028261663e81d8b5595860e.tar.gz")
             |  ^

       … while evaluating the file '/nix/store/dvd85sj784iia3g8wjhpmng2k93gqm8c-source/default.nix':

       … while evaluating the attribute 'defaultNix'
         at /nix/store/8694kanhi1kzc34kg81l33pvn638qvnh-source/default.nix:234:5:
          233|
          234|     defaultNix =
             |     ^
          235|       (builtins.removeAttrs result ["__functor"])

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: resolving Git reference 'master': revspec 'master' not found

```

</details>

Thanks, I really appreciate the project :)