### PR TITLE
fix: correct typos spotted by me

### DIFF
--- a/src/bus/dbus.rs
+++ b/src/bus/dbus.rs
@@ -83,7 +83,7 @@ impl OrgFreedesktopNotifications for Notify {
         // is effectively assigning its own id, which may interfere with ours.  Not sure how mmuch I can
         // do about this.
         let id = if replaces_id == 0 {
-            // Grab an ID atomically.  This is moreso to allow global access to `ID_COUNT`, but I'm
+            // Grab an ID atomically.  This is more so to allow global access to `ID_COUNT`, but I'm
             // also not sure if `notify` is called in a single-threaded way, so it's best to be safe.
             fetch_id()
         } else {
@@ -443,13 +443,13 @@ impl Notification {
         }
 
         // What's the difference between tag and note?
-        // A tag defines a certain type of notification, and allows it to be easily overriden using that tag.
+        // A tag defines a certain type of notification, and allows it to be easily overridden using that tag.
         // A note is supplemental data passed to the notification.  It's purely used for render
         // criteria stuff right now.
         let mut tag = arg::prop_cast::<String>(&hints, "wired-tag").cloned();
         let note = arg::prop_cast::<String>(&hints, "wired-note").cloned();
 
-        // We convert Canonical's special synchonous tag as if it was one of our own.  The
+        // We convert Canonical's special synchronous tag as if it was one of our own.  The
         // functionality is the same.  A decent overview: https://gitlab.freedesktop.org/xdg/xdg-specs/-/issues/77
         let canonical_synchronous = arg::prop_cast::<String>(&hints, "x-canonical-private-synchronous").cloned();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,7 +41,7 @@ pub enum Error {
     // Validation error.
     Validate(&'static str),
     // Bad hex string error.
-    Hexidecimal(&'static str),
+    Hexadecimal(&'static str),
     // IO error reading file.
     Io(io::Error),
     // Deserialization error.
@@ -55,7 +55,7 @@ impl std::error::Error for Error {
         match self {
             Error::NotFound => None,
             Error::Validate(_) => None,
-            Error::Hexidecimal(_) => None,
+            Error::Hexadecimal(_) => None,
             Error::Io(err) => err.source(),
             Error::Ron(err) => err.source(),
             Error::Watch(err) => err.source(),
@@ -68,8 +68,8 @@ impl Display for Error {
         match self {
             Error::NotFound => write!(f, "No config found"),
             Error::Validate(problem) => write!(f, "Error validating config file: {}", problem),
-            Error::Hexidecimal(problem) => {
-                write!(f, "Error parsing hexidecimal string: {}", problem)
+            Error::Hexadecimal(problem) => {
+                write!(f, "Error parsing hexadecimal string: {}", problem)
             }
             Error::Io(err) => write!(f, "Error reading config file: {}", err),
             Error::Ron(err) => write!(f, "Problem with config file: {}", err),
@@ -272,7 +272,7 @@ impl Config {
         }
     }
 
-    // Get mutable refernce to global config variable.
+    // Get mutable reference to global config variable.
     pub fn get_mut() -> &'static mut Config {
         unsafe {
             assert!(CONFIG.is_some());
@@ -592,7 +592,7 @@ impl Color {
         let dec = u32::from_str_radix(sanitized, 16);
         let dec = match dec {
             Ok(d) => d,
-            Err(_) => return Err(Error::Hexidecimal("Invalid hexidecimal string.")),
+            Err(_) => return Err(Error::Hexadecimal("Invalid hexadecimal string.")),
         };
 
         // If we have 8 chars, then this is hex string includes alpha, if we have 6, then it
@@ -611,7 +611,7 @@ impl Color {
             let b = (dec & 0xff) as f64 / 255.0;
             Ok(Color::from_rgba(r, g, b, a))
         } else {
-            Err(Error::Hexidecimal("Incorrect hexidecimal string length."))
+            Err(Error::Hexadecimal("Incorrect hexadecimal string length."))
         }
     }
 }
@@ -648,7 +648,7 @@ impl<'de> Deserialize<'de> for Color {
             #[allow(clippy::or_fun_call)]
             return Color::from_hex(&hex).or(Err(de::Error::invalid_value(
                 Unexpected::Str(&hex),
-                &"a valid hexidecimal string",
+                &"a valid hexadecimal string",
             )));
         } else if let (Some(r), Some(g), Some(b), Some(a)) = (col.r, col.g, col.b, col.a) {
             Ok(Color::from_rgba(r, g, b, a))

--- a/wired.ron
+++ b/wired.ron
@@ -4,7 +4,7 @@
     // A value of 0 means that there is no limit.
     max_notifications: 0,
 
-    // The default timeout, in miliseconds, for notifications that don't have an initial timeout set.
+    // The default timeout, in milliseconds, for notifications that don't have an initial timeout set.
     // 1000ms = 1s.
     timeout: 10000,
 

--- a/wired_multilayout.ron
+++ b/wired_multilayout.ron
@@ -3,7 +3,7 @@
     // A value of 0 means that there is no limit.
     max_notifications: 0,
 
-    // The default timeout, in miliseconds, for notifications that don't have an initial timeout set.
+    // The default timeout, in milliseconds, for notifications that don't have an initial timeout set.
     // 1000ms = 1s.
     timeout: 10000,
 


### PR DESCRIPTION
- update default config comments to use “milliseconds”
- rename Error::Hexidecimal variant to Error::Hexadecimal and adjust messaging
- tidy comments in DBus handling for “more so”, “overridden”, and “synchronous”

Author: rezky_nightky <with.rezky@gmail.com>
Timestamp: 2025-12-01T17:31:58Z
Repository: wired-notify
Branch: master
Signing: GPG (989AF9F0)
Performance: 4 files, +13/-13 lines