### PR TITLE
fix nix build "libxkbcommon-x11.so could not be loaded."

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         , pango
         , pkg-config
         , xorg
-        , ...
+        , libxkbcommon
         }:
         rustPlatform.buildRustPackage {
           name = "wired-${version}";
@@ -53,6 +53,12 @@
             # install example/default config files to etc/wired -- Arch packages seem to use etc/{pkg} for this,
             # so there's precedent
             install -Dm444 -t $out/etc/wired wired.ron wired_multilayout.ron
+          '';
+
+          preFixup = ''
+            patchelf $out/bin/wired \
+              --add-needed libxkbcommon-x11.so \
+              --add-rpath ${libxkbcommon}/lib
           '';
 
           meta = {


### PR DESCRIPTION
Currently running `wired` would cause this error:
```
A wired socket exists; taking ownership.
Notification bus name acquired.

thread 'main' panicked at /build/cargo-vendor-dir/xkbcommon-dl-0.4.2/src/x11.rs:59:28:
Library libxkbcommon-x11.so could not be loaded.
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR fixes it.

Note: I don't understand why this issue is only showing up right now. Maybe the binary was able to find the `.so` somewhere else, and that path is no longer available.