### PR TITLE
Dnd allow urgent notification

### DIFF
--- a/src/bus/dbus.rs
+++ b/src/bus/dbus.rs
@@ -211,7 +211,7 @@ pub fn get_connection() -> &'static Connection {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, PartialOrd)]
 pub enum Urgency {
     Low,
     Normal,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -13,6 +13,7 @@ use crate::config::FollowMode;
 use crate::{
     //notification::Notification,
     bus,
+    bus::dbus::Urgency,
     bus::dbus::Notification,
     bus::dbus_codegen::{
         OrgFreedesktopNotificationsActionInvoked, OrgFreedesktopNotificationsNotificationClosed,
@@ -143,8 +144,8 @@ impl NotifyWindowManager {
             dbg!(self.dnd, &notification);
         }
 
-        // Right now we just book it if dnd is enabled.
-        if self.dnd {
+        // Ignore non-urgent notification when dnd is on.
+        if self.dnd && notification.urgency < Urgency::Critical {
             return;
         }
 


### PR DESCRIPTION
Closes to #181, depends on #180 to fix the nix ci.

This patch would allow critical notifications to pass through even when dnd is on. It can be useful for critical system notification such as "battery low". 