### PR TITLE
check notification against a criteria when dnd is on

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -122,8 +122,8 @@ pub struct Config {
 
     // Alternative render criteria that will be checked against and allowed when dnd (do not disturb) is enabled.
     // By default, urgency "critical" is allowed.
-    #[serde(default = "Config::default_dnd_allow_render_criteria")]
-    pub dnd_allow_criteria: RenderCriteria,
+    #[serde(default = "Config::default_dnd_allow_criteria")]
+    pub dnd_allow_criteria: Vec<RenderCriteria>,
 
     // How to handle various DBus expire_timeout values
     #[serde(default)]
@@ -209,8 +209,8 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn default_dnd_allow_render_criteria() -> RenderCriteria {
-        RenderCriteria::Urgency("critical".to_owned())
+    pub fn default_dnd_allow_criteria() -> Vec<RenderCriteria> {
+        vec![RenderCriteria::Urgency("critical".to_owned())]
     }
 
     pub fn default_debug_color() -> Color {

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ use serde::{
 
 use crate::{
     maths_utility::{self, Rect, Vec2},
-    rendering::layout::{LayoutBlock, LayoutElement},
+    rendering::layout::{LayoutBlock, LayoutElement, RenderCriteria},
     rendering::text::FontOptions,
 };
 
@@ -120,6 +120,11 @@ pub struct Config {
     pub idle_poll_interval: u64, // Same as above, but when no notifications are present.
     pub layout_blocks: Vec<LayoutBlock>,
 
+    // Alternative render criteria that will be checked against and allowed when dnd (do not disturb) is enabled.
+    // By default, urgency "critical" is allowed.
+    #[serde(default = "Config::default_dnd_allow_render_criteria")]
+    pub dnd_allow_criteria: RenderCriteria,
+
     // How to handle various DBus expire_timeout values
     #[serde(default)]
     pub zero_timeout_behavior: ZeroTimeoutBehavior,
@@ -204,6 +209,10 @@ pub struct Config {
 }
 
 impl Config {
+    pub fn default_dnd_allow_render_criteria() -> RenderCriteria {
+        RenderCriteria::Urgency("critical".to_owned())
+    }
+
     pub fn default_debug_color() -> Color {
         Color::from_rgba(0.0, 1.0, 0.0, 1.0)
     }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -13,14 +13,13 @@ use crate::config::FollowMode;
 use crate::{
     //notification::Notification,
     bus,
-    bus::dbus::Urgency,
     bus::dbus::Notification,
     bus::dbus_codegen::{
         OrgFreedesktopNotificationsActionInvoked, OrgFreedesktopNotificationsNotificationClosed,
     },
     config::Config,
     maths_utility::{self, Rect},
-    rendering::layout::LayoutBlock,
+    rendering::layout::{criteria_matches, LayoutBlock},
     rendering::window::{NotifyWindow, UpdateModes},
 };
 
@@ -144,8 +143,8 @@ impl NotifyWindowManager {
             dbg!(self.dnd, &notification);
         }
 
-        // Ignore non-urgent notification when dnd is on.
-        if self.dnd && notification.urgency < Urgency::Critical {
+        // Show nothing unless dnd allow criteria says so.
+        if self.dnd && !criteria_matches(&cfg.dnd_allow_render_criteria, &notification) {
             return;
         }
 

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -10,6 +10,7 @@ use winit::{
 };
 
 use crate::config::FollowMode;
+use crate::rendering::layout::{Logic, logic_matches};
 use crate::{
     //notification::Notification,
     bus,
@@ -19,7 +20,7 @@ use crate::{
     },
     config::Config,
     maths_utility::{self, Rect},
-    rendering::layout::{criteria_matches, LayoutBlock},
+    rendering::layout::LayoutBlock,
     rendering::window::{NotifyWindow, UpdateModes},
 };
 
@@ -144,7 +145,7 @@ impl NotifyWindowManager {
         }
 
         // Show nothing unless dnd allow criteria says so.
-        if self.dnd && !criteria_matches(&cfg.dnd_allow_render_criteria, &notification) {
+        if self.dnd && !logic_matches(Logic::Or, &cfg.dnd_allow_criteria, &notification) {
             return;
         }
 

--- a/src/rendering/layout.rs
+++ b/src/rendering/layout.rs
@@ -58,7 +58,7 @@ pub enum RenderCriteria {
     Not(Box<RenderCriteria>),
 }
 
-enum Logic {
+pub(crate) enum Logic {
     And,
     Or,
 }
@@ -111,7 +111,7 @@ pub(crate) fn criteria_matches(criteria: &RenderCriteria, notification: &Notific
     }
 }
 
-fn logic_matches(logic: Logic, criterion: &Vec<RenderCriteria>, notification: &Notification) -> bool {
+pub(crate) fn logic_matches(logic: Logic, criterion: &Vec<RenderCriteria>, notification: &Notification) -> bool {
     let mut result;
     match logic {
         Logic::And => {

--- a/src/rendering/layout.rs
+++ b/src/rendering/layout.rs
@@ -87,54 +87,54 @@ pub enum LayoutElement {
     ProgressBlock(ProgressBlockParameters),
 }
 
+pub(crate) fn criteria_matches(criteria: &RenderCriteria, notification: &Notification) -> bool {
+    match criteria {
+        RenderCriteria::Summary => !notification.summary.is_empty(),
+        RenderCriteria::Body => !notification.body.is_empty(),
+        RenderCriteria::AppImage => notification.app_image.is_some(),
+        RenderCriteria::HintImage => notification.hint_image.is_some(),
+        RenderCriteria::AppName(name) => notification.app_name.eq(name),
+        RenderCriteria::Progress => notification.percentage.is_some(),
+        RenderCriteria::Urgency(u) => match notification.urgency {
+            Urgency::Low => u.eq("low"),
+            Urgency::Normal => u.eq("normal"),
+            Urgency::Critical => u.eq("critical"),
+        },
+        RenderCriteria::Tag(t) => notification.tag.as_ref().eq(&Some(t)),
+        RenderCriteria::Note(n) => notification.note.as_ref().eq(&Some(n)),
+        RenderCriteria::ActionDefault => notification.get_default_action().is_some(),
+        RenderCriteria::ActionOther(i) => notification.get_other_action(*i).is_some(),
+
+        RenderCriteria::And(criterion) => logic_matches(Logic::And, criterion, notification),
+        RenderCriteria::Or(criterion) => logic_matches(Logic::Or, criterion, notification),
+        RenderCriteria::Not(criterion) => !criteria_matches(criterion, notification),
+    }
+}
+
+fn logic_matches(logic: Logic, criterion: &Vec<RenderCriteria>, notification: &Notification) -> bool {
+    let mut result;
+    match logic {
+        Logic::And => {
+            // ANDs start as true to coalesce properly.
+            result = true;
+            for c in criterion {
+                result &= criteria_matches(c, notification);
+            }
+        }
+        Logic::Or => {
+            // ORs start as false to coalesce properly.
+            result = false;
+            for c in criterion {
+                result |= criteria_matches(c, notification);
+            }
+        }
+    }
+
+    result
+}
+
 impl LayoutBlock {
     pub fn should_draw(&self, notification: &Notification) -> bool {
-        fn criteria_matches(criteria: &RenderCriteria, notification: &Notification) -> bool {
-            match criteria {
-                RenderCriteria::Summary => !notification.summary.is_empty(),
-                RenderCriteria::Body => !notification.body.is_empty(),
-                RenderCriteria::AppImage => notification.app_image.is_some(),
-                RenderCriteria::HintImage => notification.hint_image.is_some(),
-                RenderCriteria::AppName(name) => notification.app_name.eq(name),
-                RenderCriteria::Progress => notification.percentage.is_some(),
-                RenderCriteria::Urgency(u) => match notification.urgency {
-                    Urgency::Low => u.eq("low"),
-                    Urgency::Normal => u.eq("normal"),
-                    Urgency::Critical => u.eq("critical"),
-                },
-                RenderCriteria::Tag(t) => notification.tag.as_ref().eq(&Some(t)),
-                RenderCriteria::Note(n) => notification.note.as_ref().eq(&Some(n)),
-                RenderCriteria::ActionDefault => notification.get_default_action().is_some(),
-                RenderCriteria::ActionOther(i) => notification.get_other_action(*i).is_some(),
-
-                RenderCriteria::And(criterion) => logic_matches(Logic::And, criterion, notification),
-                RenderCriteria::Or(criterion) => logic_matches(Logic::Or, criterion, notification),
-                RenderCriteria::Not(criterion) => !criteria_matches(criterion, notification),
-            }
-        }
-
-        fn logic_matches(logic: Logic, criterion: &Vec<RenderCriteria>, notification: &Notification) -> bool {
-            let mut result;
-            match logic {
-                Logic::And => {
-                    // ANDs start as true to coalesce properly.
-                    result = true;
-                    for c in criterion {
-                        result &= criteria_matches(c, notification);
-                    }
-                }
-                Logic::Or => {
-                    // ORs start as false to coalesce properly.
-                    result = false;
-                    for c in criterion {
-                        result |= criteria_matches(c, notification);
-                    }
-                }
-            }
-
-            result
-        }
-
         // Sometimes users might want to render empty blocks to maintain padding and stuff, so we
         // optionally allow it (in the case that both render_criterias are empty).
 

--- a/wired.ron
+++ b/wired.ron
@@ -25,7 +25,7 @@
 
     // // Alternative render criteria that will be checked against and allowed when dnd (do not disturb) is enabled.
     // // By default, urgency "critical" is allowed.
-    // dnd_allow_render_criteria: Urgency("critical"),
+    // dnd_allow_criteria: [Urgency("critical")],
 
     // The interval at which wired updates when no notifications/windows are present.
     //idle_poll_interval: 500,

--- a/wired.ron
+++ b/wired.ron
@@ -23,6 +23,10 @@
     // 16ms ~= 60hz / 7ms ~= 144hz.
     poll_interval: 16,
 
+    // // Alternative render criteria that will be checked against and allowed when dnd (do not disturb) is enabled.
+    // // By default, urgency "critical" is allowed.
+    // dnd_allow_render_criteria: Urgency("critical"),
+
     // The interval at which wired updates when no notifications/windows are present.
     //idle_poll_interval: 500,
 


### PR DESCRIPTION
I realized that there's already a mechanism to match on notification for rendering blocks! It even already has its own deserialization defaults in the config!

So I added configuration option `dnd_allow_render_criteria`. When dnd is on, this criteria would allow notifications to pass through, with granular control matching on the properties of a notification.

This succeeds #182 by doing it properly. 